### PR TITLE
build: default to visibility hidden

### DIFF
--- a/vc2hqencode/Makefile.am
+++ b/vc2hqencode/Makefile.am
@@ -25,7 +25,8 @@ libvc2hqencode_@VC2HQENCODE_MAJORMINOR@_la_LDFLAGS = \
 libvc2hqencode_@VC2HQENCODE_MAJORMINOR@_la_CPPFLAGS = $(VC2HQENCODE_CFLAGS) \
 	$(BOOST_CFLAGS) \
 	-I$(top_srcdir) \
-	-I$(top_srcdir)/redist
+	-I$(top_srcdir)/redist \
+	-fvisibility=hidden
 
 libvc2hqencode_@VC2HQENCODE_MAJORMINOR@_la_SOURCES = vc2hqencode.cpp \
 	VC2Encoder.cpp \
@@ -54,7 +55,8 @@ noinst_HEADERS = VC2Encoder.hpp \
   intdivide.hpp \
   debug.hpp \
   quantiserselection.hpp \
-	encode_slice_component_optimised.hpp
+	encode_slice_component_optimised.hpp \
+	internal.h
 
 nodist_pkginclude_HEADERS = vc2hqencode-stdint.h
 

--- a/vc2hqencode/VC2Encoder.hpp
+++ b/vc2hqencode/VC2Encoder.hpp
@@ -28,7 +28,7 @@
 
 #include <atomic>
 
-#include "vc2hqencode.h"
+#include "internal.h"
 #include "VideoFormat.hpp"
 #include "encode.hpp"
 #include "serialise.hpp"

--- a/vc2hqencode/VideoFormat.hpp
+++ b/vc2hqencode/VideoFormat.hpp
@@ -26,7 +26,7 @@
 #ifndef __VIDEOFORMAT_HPP__
 #define __VIDEOFORMAT_HPP__
 
-#include "vc2hqencode.h"
+#include "internal.h"
 
 namespace vc2 {
   struct FrameRate {

--- a/vc2hqencode/encode.cpp
+++ b/vc2hqencode/encode.cpp
@@ -23,7 +23,7 @@
  * For more information, contact us at ipstudio@bbc.co.uk.
  *****************************************************************************/
 
-#include "vc2hqencode.h"
+#include "internal.h"
 #include "encode.hpp"
 #include "lut.hpp"
 #include "logger.hpp"

--- a/vc2hqencode/internal.h
+++ b/vc2hqencode/internal.h
@@ -1,7 +1,7 @@
 /*****************************************************************************
- * logger.cpp : Logging
+ * internal.h : internal data structures and defines needed by the encoder
  *****************************************************************************
- * Copyright (C) 2014-2015 BBC
+ * Copyright (C) 2014-2016 BBC
  *
  * Authors: James P. Weaver <james.barrett@bbc.co.uk>
  *
@@ -23,53 +23,11 @@
  * For more information, contact us at ipstudio@bbc.co.uk.
  *****************************************************************************/
 
-#include "internal.h"
-#include "logger.hpp"
+#ifndef __INTERNAL_HPP__
+#define __INTERNAL_HPP__
 
-#include <cstdio>
-#include <ctime>
-#include <cstdarg>
-#include <cstdlib>
+#include <stdint.h>
+#define VC2HQENCODE_DLL
+#include "vc2hqencode.h"
 
-VC2EncoderLoggers loggers = { 0, 0, 0, 0, 0 };
-
-const char *loglevels[] = { "ERROR", "WARNING", "INFO", "DEBUG" };
-
-void vc2encoder_init_logging(VC2EncoderLoggers l) {
-  loggers = l;
-}
-
-void writelog(int level, const char *fmt, ...) {
-  va_list args;
-  char *msg;
-  va_start(args, fmt);
-  if (vasprintf(&msg, fmt, args) < 0)
-    return;
-
-  switch(level) {
-  case LOG_DEBUG:
-    if (loggers.debug) {
-      loggers.debug(msg, loggers.opaque);
-      break;
-    }
-  case LOG_INFO:
-    if (loggers.info) {
-      loggers.info(msg, loggers.opaque);
-      break;
-    }
-  case LOG_WARN:
-    if (loggers.warn) {
-      loggers.warn(msg, loggers.opaque);
-      break;
-    }
-  case LOG_ERROR:
-    if (loggers.error) {
-      loggers.error(msg, loggers.opaque);
-      break;
-    }
-  default:
-    fprintf(stderr, "%s: %s\n", loglevels[level], msg);
-  }
-
-  free(msg);
-}
+#endif /* __INTERNAL_HPP__ */

--- a/vc2hqencode/quantise.cpp
+++ b/vc2hqencode/quantise.cpp
@@ -24,7 +24,7 @@
  *****************************************************************************/
 
 #include "quantise.hpp"
-#include "vc2hqencode.h"
+#include "internal.h"
 #include "logger.hpp"
 #include <stdlib.h>
 

--- a/vc2hqencode/serialise.hpp
+++ b/vc2hqencode/serialise.hpp
@@ -27,7 +27,7 @@
 #define __SERIALISE_HPP__
 
 #include "datastructures.hpp"
-#include "vc2hqencode.h"
+#include "internal.h"
 #include "logger.hpp"
 #include "debug.hpp"
 

--- a/vc2hqencode/stream.hpp
+++ b/vc2hqencode/stream.hpp
@@ -26,7 +26,7 @@
 #ifndef __STREAM_HPP__
 #define __STREAM_HPP__
 
-#include "vc2hqencode.h"
+#include "internal.h"
 #include <cstdlib>
 
 class SequenceHeader {

--- a/vc2hqencode/transform.hpp
+++ b/vc2hqencode/transform.hpp
@@ -29,7 +29,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#include "vc2hqencode.h"
+#include "internal.h"
 
 typedef void (*InplaceTransform)(void *idata,
                                  const int istride,

--- a/vc2hqencode/vc2hqencode.cpp
+++ b/vc2hqencode/vc2hqencode.cpp
@@ -23,7 +23,7 @@
  * For more information, contact us at ipstudio@bbc.co.uk.
  *****************************************************************************/
 
-#include "vc2hqencode.h"
+#include "internal.h"
 #include "VC2Encoder.hpp"
 
 #define VC2ENCODER_BEGIN \

--- a/vc2hqencode/vc2hqencode.h
+++ b/vc2hqencode/vc2hqencode.h
@@ -28,6 +28,25 @@
 
 #include <stdint.h>
 
+#if defined _WIN32 || defined __CYGWIN__
+  #define VC2HQENCODE_EXPORT __declspec(dllexport)
+  #define VC2HQENCODE_IMPORT __declspec(dllimport)
+#else
+  #if __GNUC__ >= 4
+    #define VC2HQENCODE_EXPORT __attribute__((visibility("default")))
+    #define VC2HQENCODE_IMPORT __attribute__((visibility("default")))
+  #else
+    #define VC2HQENCODE_EXPORT
+    #define VC2HQENCODE_IMPORT
+  #endif
+#endif
+
+#ifdef VC2HQENCODE_DLL
+#define VC2HQENCODE_API VC2HQENCODE_EXPORT
+#else
+#define VC2HQENCODE_API VC2HQENCODE_IMPORT
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -285,24 +304,24 @@ typedef struct _VC2EncoderLoggers {
    And in addition each sequence also needs to set asside enough space for the sequence_start_size and sequence_end_size. How many frames you put between these is up to you.
  */
 
-void vc2encode_init();
-void vc2encoder_init_logging(VC2EncoderLoggers);
-VC2EncoderHandle vc2encode_create();
-VC2EncoderResult vc2encode_set_parameters(VC2EncoderHandle, VC2EncoderParams);
-VC2EncoderResult vc2encode_get_parameters(VC2EncoderHandle, VC2EncoderParams *);
+VC2HQENCODE_API void vc2encode_init();
+VC2HQENCODE_API void vc2encoder_init_logging(VC2EncoderLoggers);
+VC2HQENCODE_API VC2EncoderHandle vc2encode_create();
+VC2HQENCODE_API VC2EncoderResult vc2encode_set_parameters(VC2EncoderHandle, VC2EncoderParams);
+VC2HQENCODE_API VC2EncoderResult vc2encode_get_parameters(VC2EncoderHandle, VC2EncoderParams *);
 
-VC2EncoderResult vc2encode_get_sequence_start_size(VC2EncoderHandle, uint32_t *size);
-VC2EncoderResult vc2encode_start_sequence(VC2EncoderHandle, char **data, uint32_t *next_parse_offset);
-VC2EncoderResult vc2encode_repeat_sequence_start(VC2EncoderHandle, char **data, uint32_t prev_parse_offset, uint32_t *next_parse_offset);
-VC2EncoderResult vc2encode_get_coded_picture_start_size(VC2EncoderHandle, uint32_t *size);
-VC2EncoderResult vc2encode_start_picture(VC2EncoderHandle handle, char **data, uint32_t prev_parse_offset, uint32_t picture_number, int data_length, uint32_t *next_parse_offset);
-VC2EncoderResult vc2encode_encode_data(VC2EncoderHandle, char **idata, int *istride, char **odata, int length);
-VC2EncoderResult vc2encode_get_auxiliary_data_start_size(VC2EncoderHandle, uint32_t *size);
-VC2EncoderResult vc2encode_start_auxiliary_data(VC2EncoderHandle handle, char **data, uint32_t prev_parse_offset, int data_length, uint32_t *next_parse_offset);
-VC2EncoderResult vc2encode_get_sequence_end_size(VC2EncoderHandle, uint32_t *size);
-VC2EncoderResult vc2encode_end_sequence(VC2EncoderHandle, char **data, uint32_t prev_parse_offset);
+VC2HQENCODE_API VC2EncoderResult vc2encode_get_sequence_start_size(VC2EncoderHandle, uint32_t *size);
+VC2HQENCODE_API VC2EncoderResult vc2encode_start_sequence(VC2EncoderHandle, char **data, uint32_t *next_parse_offset);
+VC2HQENCODE_API VC2EncoderResult vc2encode_repeat_sequence_start(VC2EncoderHandle, char **data, uint32_t prev_parse_offset, uint32_t *next_parse_offset);
+VC2HQENCODE_API VC2EncoderResult vc2encode_get_coded_picture_start_size(VC2EncoderHandle, uint32_t *size);
+VC2HQENCODE_API VC2EncoderResult vc2encode_start_picture(VC2EncoderHandle handle, char **data, uint32_t prev_parse_offset, uint32_t picture_number, int data_length, uint32_t *next_parse_offset);
+VC2HQENCODE_API VC2EncoderResult vc2encode_encode_data(VC2EncoderHandle, char **idata, int *istride, char **odata, int length);
+VC2HQENCODE_API VC2EncoderResult vc2encode_get_auxiliary_data_start_size(VC2EncoderHandle, uint32_t *size);
+VC2HQENCODE_API VC2EncoderResult vc2encode_start_auxiliary_data(VC2EncoderHandle handle, char **data, uint32_t prev_parse_offset, int data_length, uint32_t *next_parse_offset);
+VC2HQENCODE_API VC2EncoderResult vc2encode_get_sequence_end_size(VC2EncoderHandle, uint32_t *size);
+VC2HQENCODE_API VC2EncoderResult vc2encode_end_sequence(VC2EncoderHandle, char **data, uint32_t prev_parse_offset);
 
-void vc2encode_destroy(VC2EncoderHandle);
+VC2HQENCODE_API void vc2encode_destroy(VC2EncoderHandle);
 
 #ifdef __cplusplus
 };


### PR DESCRIPTION
Change the symbol visibility to hidden to avoid non-API symbols being exposed and causing compatibility problems with other software using the same symbols, e.g. other software not compiled with C++11.
