### PR TITLE
Two small changes

### DIFF
--- a/testprogs/vc2encode.cpp
+++ b/testprogs/vc2encode.cpp
@@ -183,7 +183,10 @@ int main (int argc, char *argv[]) {
       std::stringstream ss;
       ss << "zoneplate_" << width << "x" << height << "_" << wavelet_string << "_";
       ss << slice_width << "x" << slice_height << "x" << depth << "_";
-      ss << speed_string << "_" << num_frames << "frames_" << threads_number << "threads" << ".vc2";
+      ss << speed_string << "_" << num_frames << "frames_" << threads_number << "threads";
+      if (fragment_size)
+          ss << "_fragments";
+      ss << ".vc2";
       output_filename = ss.str();
     }
   }

--- a/testprogs/vc2encode.cpp
+++ b/testprogs/vc2encode.cpp
@@ -182,10 +182,7 @@ int main (int argc, char *argv[]) {
     {
       std::stringstream ss;
       ss << "zoneplate_" << width << "x" << height << "_" << wavelet_string << "_";
-      if (depth == 2)
-        ss << "8x8x2_";
-      else
-        ss << "32x8x3_";
+      ss << slice_width << "x" << slice_height << "x" << depth << "_";
       ss << speed_string << "_" << num_frames << "frames_" << threads_number << "threads" << ".vc2";
       output_filename = ss.str();
     }

--- a/vc2hqencode/VC2Encoder.cpp
+++ b/vc2hqencode/VC2Encoder.cpp
@@ -265,7 +265,9 @@ void VC2Encoder::setParams(VC2EncoderParams &params) throw(VC2EncoderResult){
 
   if ((mPaddedWidth%params.transform_params.slice_width != 0) ||
       (mPaddedHeight%params.transform_params.slice_height != 0)) {
-    writelog(LOG_ERROR, "%s:%d: Support for slice sizes which do not divide the padded picture size is not implemented.\n", __FILE__, __LINE__);
+    writelog(LOG_ERROR, "%s:%d: Support for slice sizes (%dx%d) which do not divide the padded picture size (%dx%d) is not implemented.\n", __FILE__, __LINE__,
+            params.transform_params.slice_width, params.transform_params.slice_height,
+            mPaddedWidth, mPaddedHeight);
     throw VC2ENCODER_BADPARAMS;
   }
 


### PR DESCRIPTION
First, have the encoder program create the zoneplate output filename using *slice* width and height and the *wavelet* depth.

Second, show the values in an error message about variable slice geometry.  If one doesn't know the default slice sizes, or about padding, or about separated fields (interlaced encoding) then the base error message can leave one wondering.