### PR TITLE
Add missing #include

### DIFF
--- a/vc2hqencode/thread_group.hpp
+++ b/vc2hqencode/thread_group.hpp
@@ -28,6 +28,7 @@
 
 #include <thread>
 #include <algorithm>
+#include <vector>
 
 class thread_group {
 public:


### PR DESCRIPTION
The definition of `thread_group` uses `std::vector`.

This fixes a build failure using GCC 10.2; I expect `<vector>` was being transitively included from one of the other headers before.