### PR TITLE
Fixed build process

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,7 @@ LT_INIT(disable-static win32-dll)
 
 AC_PROG_CXX
 AM_PROG_CC_C_O
-
+CXXFLAGS="$CXXFLAGS -std=c++11"
 AC_CXX_HAVE_SSTREAM
 
 AC_CONFIG_SRCDIR([vc2hqencode/vc2hqencode.h])
@@ -61,9 +61,9 @@ debug_default="no"
 AC_ARG_ENABLE(debug, [  --enable-debug=[no/yes] turn on debugging
 					   [default=$debug_default]],, enable_debug=$debug_default)
 if test "x$enable_debug" = "xyes"; then
-		 VC2HQENCODE_CFLAGS="$VC2HQENCODE_CFLAGS -g -Og -DDEBUG"
-		 CXXFLAGS="$CXXFLAGS -O0"
-     VC2HQENCODE_LDFLAGS="$VC2HQENCODE_LDFLAGS -pg"
+    VC2HQENCODE_CFLAGS="$VC2HQENCODE_CFLAGS -g -Og -DDEBUG"
+    CXXFLAGS="$CXXFLAGS -O0"
+    VC2HQENCODE_LDFLAGS="$VC2HQENCODE_LDFLAGS -pg"
 AC_MSG_RESULT(yes)
 else
 AC_MSG_RESULT(no)

--- a/duplicate-transform
+++ b/duplicate-transform
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/bin/bash
 
 #*****************************************************************************
 #* duplicate-transform: A script that duplicates the transform headers
@@ -25,18 +25,9 @@
 #* For more information, contact us at ipstudio@bbc.co.uk.
 #*****************************************************************************
 
-import sys
-import re
+infilename="$1"
+outfilename="$2"
+inext="$3"
+outext="$4"
 
-infilename = sys.argv[1]
-outfilename = sys.argv[2]
-
-inext = sys.argv[3]
-outext = sys.argv[4]
-
-fi = open(infilename, 'r')
-fo = open(outfilename, 'w')
-
-for l in fi:
-    l = re.sub(inext, outext, l)
-    fo.write(l)
+sed "s/${inext}/${outext}/g" "$infilename" > "$outfilename"


### PR DESCRIPTION
The project implicitly uses the C++11 standard, leading to compilation errors when running `make` since some features used have been completely deprecated. This patch specifies the need to compile using C++11 in `configure.ac.`

Furthermore, the python script `duplicate-transform` does not execute correctly when running `make`, so a Bash equivalent using `sed` has been provided, which now performs the same task.